### PR TITLE
Add Markdown supports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,25 @@ target/
 .DS_Store
 ._.DS_Store
 
-config.json
+# Docker Files
 mnt
 data
 docker-compose.dev.yml
+
+# TeleGPT Default Config Files
+*.config.json
+config.json
+
+# Visual Studio Code Configurations
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "TeleGPT Nightly",
+            "cargo": {
+                "args": ["build", "--bin=telegpt", "--package=telegpt"],
+                "filter": {
+                    "name": "telegpt",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "RUST_LOG": "DEBUG"
+            }
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,7 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
+                "RUST_BACKTRACE": "full",
                 "RUST_LOG": "DEBUG"
             }
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.8.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c791cd9568241317f49bb3e3a6b595c986a2022428caa16a316be2520d05acf1"
+checksum = "25a497fb330310be352a9e30a040804cd3f16f5ae2e57eeedd50c0f530189c88"
 dependencies = [
  "backoff",
  "base64",
@@ -560,6 +560,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1143,6 +1152,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1518,7 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "pretty_env_logger",
+ "pulldown-cmark",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1769,6 +1791,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ strip = true
 
 [dependencies]
 teloxide = { version = "0.12", features = ["macros"] }
-async-openai = "0.8"
+async-openai = "0.9"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 pin-project-lite = "0.2"
@@ -35,3 +35,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 paste = "1.0"
 clap = { version = "4.0", features = ["derive"] }
+pulldown-cmark = "0.9"

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ TeleGPT is a Telegram bot based on [**teloxide**](https://github.com/teloxide/te
 
 ## Features
 
-🦀 **Lightning fast** with pure Rust codebase.<br>
-📢 **All types of chat** (private and group) supports.<br>
-🚀 **Live streaming tokens** to your message bubble.<br>
-💸 **Token usage** statistic recording and queryable via commands.<br>
-⚙️ **Fully customizable** with file-based configuration.<br>
+🦀 **Lightning fast** with pure Rust codebase.  
+📢 **All types of chat** (private and group) supports.  
+🚀 **Live streaming tokens** to your message bubble.  
+⌨️ **Telegram-flavoured Markdown** rendering supports.  
+💸 **Token usage** statistic recording and queryable via commands.  
+⚙️ **Fully customizable** with file-based configuration.  
 ✋ **Admin features** (Beta) and user access control supports.
 
 ## Getting TeleGPT

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,13 @@ pub struct Config {
     #[serde(default = "default_conversation_limit", rename = "conversationLimit")]
     pub conversation_limit: u64,
 
+    /// A boolean value that indicates whether to parse and render the
+    /// markdown contents. When set to `false`, the raw contents returned
+    /// from OpenAI will be displayed. This is default to `false`.
+    /// JSON key: `rendersMarkdown`
+    #[serde(default = "default_renders_markdown", rename = "rendersMarkdown")]
+    pub renders_markdown: bool,
+
     /// A path for storing the database, [`None`] for in-memory database.
     /// JSON key: `databasePath`
     #[serde(rename = "databasePath")]
@@ -142,6 +149,7 @@ define_defaults! {
     openai_api_timeout: u64 = 10,
     stream_throttle_interval: u64 = 500,
     conversation_limit: u64 = 20,
+    renders_markdown: bool = false,
 }
 
 define_defaults!(I18nStrings {

--- a/src/modules/chat/markdown.rs
+++ b/src/modules/chat/markdown.rs
@@ -323,13 +323,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn my_test() {
-        let content = "\n\n```rust\nfn is_prime(num: u64) -> bool {\n    if num <= 1 {\n        return false;\n    }\n    for i in 2..=((num as f64).sqrt() as u64) {\n        if num % i == 0 {\n            return false;\n        }\n    }\n    return true;\n}\n\nfn main() {\n    let num = 17;\n    if is_prime(num) {\n        println!(\"{} is a prime number\", num);\n    } else {\n        println!(\"{} is not a prime number\", num);\n    }\n}\n```\n\n输出：\n\n```\n17 is a prime number\n```";
-        let events: Vec<_> = pulldown_cmark::Parser::new(content).collect();
-        println!("{:#?}", events);
-    }
-
-    #[test]
     fn test_parse_simple() {
         let raw = r#"# Heading
 - list item 1

--- a/src/modules/chat/markdown.rs
+++ b/src/modules/chat/markdown.rs
@@ -1,0 +1,315 @@
+use anyhow::Ok;
+use pulldown_cmark::{
+    CowStr, Event as CmarkEvent, Options as CmarkOptions, Parser as CmarkParser, Tag as CmarkTag,
+};
+use teloxide::types::{MessageEntity, MessageEntityKind};
+
+#[derive(Debug)]
+pub struct ParsedString {
+    pub content: String,
+    pub entities: Vec<MessageEntity>,
+}
+
+impl ParsedString {
+    fn new() -> Self {
+        Self {
+            content: String::new(),
+            entities: Vec::new(),
+        }
+    }
+
+    fn trimmed(mut self) -> Self {
+        self.content.truncate(self.content.trim().len());
+        self
+    }
+}
+
+enum Event<'a> {
+    Start(Tag<'a>),
+    End(Tag<'a>),
+    Text(CowStr<'a>),
+    Code(CowStr<'a>),
+    Break,
+}
+
+#[derive(Debug)]
+enum Tag<'a> {
+    Paragraph,
+    Heading(u32),
+    CodeBlock,
+    List(Option<u64>),
+    Item,
+    Italic,
+    Bold,
+    Strikethrough,
+    Link(CowStr<'a>),
+    Image(CowStr<'a>),
+}
+
+impl<'a> TryFrom<CmarkTag<'a>> for Tag<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: CmarkTag<'a>) -> Result<Self, Self::Error> {
+        let mapped = match value {
+            CmarkTag::Paragraph | CmarkTag::BlockQuote => Tag::Paragraph,
+            CmarkTag::Heading(level, _, _) => Tag::Heading(level as _),
+            CmarkTag::CodeBlock(_) => Tag::CodeBlock,
+            CmarkTag::List(first) => Tag::List(first),
+            CmarkTag::Item => Tag::Item,
+            CmarkTag::Emphasis => Tag::Italic,
+            CmarkTag::Strong => Tag::Bold,
+            CmarkTag::Strikethrough => Tag::Strikethrough,
+            CmarkTag::Link(_, url, _) => Tag::Link(url),
+            CmarkTag::Image(_, url, _) => Tag::Image(url),
+            _ => return Err(anyhow!("Unexpected tag: {:?}", value)),
+        };
+        Ok(mapped)
+    }
+}
+
+impl<'a> TryFrom<CmarkEvent<'a>> for Event<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: CmarkEvent<'a>) -> Result<Self, Self::Error> {
+        let mapped = match value {
+            CmarkEvent::Start(tag) => Event::Start(tag.try_into()?),
+            CmarkEvent::End(tag) => Event::End(tag.try_into()?),
+            CmarkEvent::Text(text) => Event::Text(text),
+            CmarkEvent::Html(text) | CmarkEvent::Code(text) => Event::Code(text),
+            CmarkEvent::SoftBreak | CmarkEvent::HardBreak => Event::Break,
+            CmarkEvent::Rule => Event::Text(CowStr::Borrowed("---")),
+            _ => {
+                return Err(anyhow!("Unexpected event: {:?}", value));
+            }
+        };
+        Ok(mapped)
+    }
+}
+
+#[derive(Debug)]
+enum EntityKind {
+    TelegramEntityKind(MessageEntityKind),
+    List(Option<u64>),
+}
+
+impl<'a> TryFrom<Tag<'a>> for EntityKind {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Tag<'a>) -> Result<Self, Self::Error> {
+        let mapped = match value {
+            Tag::List(start) => EntityKind::List(start),
+            Tag::CodeBlock => EntityKind::TelegramEntityKind(MessageEntityKind::Code),
+            Tag::Italic => EntityKind::TelegramEntityKind(MessageEntityKind::Italic),
+            Tag::Bold => EntityKind::TelegramEntityKind(MessageEntityKind::Bold),
+            Tag::Strikethrough => EntityKind::TelegramEntityKind(MessageEntityKind::Strikethrough),
+            Tag::Link(url) | Tag::Image(url) => {
+                EntityKind::TelegramEntityKind(MessageEntityKind::TextLink {
+                    url: url.parse().unwrap(),
+                })
+            }
+            _ => {
+                return Err(anyhow!("Unexpected tag: {:?}", value));
+            }
+        };
+        Ok(mapped)
+    }
+}
+
+#[derive(Debug)]
+struct Entity {
+    kind: EntityKind,
+    start: usize,
+}
+
+#[derive(Debug)]
+struct ParseState {
+    entity_stack: Vec<Entity>,
+    parsed_string: ParsedString,
+    utf16_offset: usize,
+}
+
+impl ParseState {
+    fn new() -> Self {
+        Self {
+            entity_stack: Vec::new(),
+            parsed_string: ParsedString::new(),
+            utf16_offset: 0,
+        }
+    }
+
+    fn next_state(mut self, event: Event) -> Self {
+        match event {
+            Event::Start(tag) => self.start(tag),
+            Event::End(tag) => self.end(tag),
+            Event::Text(text) => self.text(text),
+            Event::Code(text) => self.code(text),
+            Event::Break => self.r#break(),
+        };
+        self
+    }
+
+    fn start(&mut self, tag: Tag) {
+        match tag {
+            Tag::Paragraph => {}
+            Tag::Heading(level) => {
+                self.push_str(&format!("{} ", "#".repeat(level as _)));
+            }
+            Tag::Item => {
+                let item_marker = self
+                    .entity_stack
+                    .last()
+                    .and_then(|entity| match entity.kind {
+                        EntityKind::List(Some(start)) => Some(format!("{}. ", start)),
+                        EntityKind::List(None) => Some("• ".to_owned()),
+                        _ => None,
+                    })
+                    .expect("Expected a list entity");
+                self.push_str(&item_marker);
+            }
+            _ => {
+                let entity_kind = tag.try_into().expect("Unexpected tag");
+                self.entity_stack.push(Entity {
+                    kind: entity_kind,
+                    start: self.utf16_offset,
+                });
+            }
+        }
+    }
+
+    fn end(&mut self, tag: Tag) {
+        match tag {
+            Tag::Paragraph => {
+                self.push_str("\n");
+            }
+            Tag::Heading(_) => self.push_str("\n"),
+            Tag::CodeBlock => {
+                let entity = self.entity_stack.pop().expect("Unmatched end tag");
+                self.parsed_string.entities.push(MessageEntity {
+                    kind: MessageEntityKind::Code,
+                    offset: entity.start,
+                    length: self.utf16_offset - entity.start,
+                });
+                self.push_str("\n");
+            }
+            Tag::List(_) => {
+                self.entity_stack.pop().expect("Unmatched end tag");
+                self.push_str("\n");
+            }
+            Tag::Item => {
+                self.push_str("\n");
+                if let Some(Entity {
+                    kind: EntityKind::List(maybe_start_number),
+                    ..
+                }) = self.entity_stack.last_mut()
+                {
+                    if let Some(start_number) = maybe_start_number {
+                        *start_number += 1;
+                    }
+                } else {
+                    panic!("Unmatched end tag");
+                }
+            }
+            Tag::Italic | Tag::Bold | Tag::Strikethrough => {
+                let Entity { kind, start } = self.entity_stack.pop().expect("Unmatched end tag");
+                self.parsed_string.entities.push(MessageEntity {
+                    kind: if let EntityKind::TelegramEntityKind(kind) = kind {
+                        kind
+                    } else {
+                        panic!("Unexpected entity kind: {:?}", kind)
+                    },
+                    offset: start,
+                    length: self.utf16_offset - start,
+                });
+            }
+            Tag::Link(_) | Tag::Image(_) => {
+                if let Some(Entity {
+                    kind: EntityKind::TelegramEntityKind(kind),
+                    start,
+                }) = self.entity_stack.pop()
+                {
+                    self.parsed_string.entities.push(MessageEntity {
+                        kind,
+                        offset: start,
+                        length: self.utf16_offset - start,
+                    });
+                } else {
+                    panic!("Unmatched end tag");
+                }
+            }
+        }
+    }
+
+    fn text(&mut self, text: CowStr) {
+        self.push_str(&text);
+    }
+
+    fn code(&mut self, text: CowStr) {
+        let offset = self.utf16_offset;
+        self.push_str(&text);
+        self.parsed_string.entities.push(MessageEntity {
+            kind: MessageEntityKind::Code,
+            offset,
+            length: self.utf16_offset - offset,
+        });
+    }
+
+    fn r#break(&mut self) {
+        self.push_str("\n");
+    }
+
+    fn push_str(&mut self, string: &str) {
+        let utf16_len_inc = string.encode_utf16().count();
+        self.parsed_string.content.push_str(string);
+        self.utf16_offset += utf16_len_inc;
+    }
+}
+
+#[allow(unused)]
+pub fn parse(content: &str) -> ParsedString {
+    let mut options = CmarkOptions::empty();
+    options.insert(CmarkOptions::ENABLE_STRIKETHROUGH);
+    let parser = CmarkParser::new_ext(content, options);
+
+    parser
+        .filter_map(|event| {
+            #[cfg(debug_assertions)]
+            {
+                Some(Event::try_from(event).expect("Unexpected event"))
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                Event::try_from(event).ok()
+            }
+        })
+        .fold(ParseState::new(), |acc, event| acc.next_state(event))
+        .parsed_string
+        .trimmed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        let content = r#"
+很抱歉，我理解有误。以下是将 `title` 属性添加到 Markdown 格式的图片标题中的无序列表：
+
+- 苹果 ![苹果](https://img.icons8.com/color/48/000000/apple.png)
+- 香蕉 ![香蕉](https://img.icons8.com/color/48/000000/banana.png)
+- 草莓 ![草莓](https://img.icons8.com/color/48/000000/strawberry.png)
+- 橙子 ![橙子](https://img.icons8.com/color/48/000000/orange.png)
+- 葡萄 ![葡萄](https://img.icons8.com/color/48/000000/grapes.png)
+
+```rust
+fn main() {
+
+}
+```
+
+这是一个**加粗**文本
+"#;
+        let parsed = parse(content);
+        println!("{:#?}", parsed);
+    }
+}

--- a/src/modules/chat/mod.rs
+++ b/src/modules/chat/mod.rs
@@ -290,6 +290,7 @@ async fn stream_model_result(
         // in stream mode. Therefore we need to estimate it locally.
         last_response.token_usage =
             openai_client::estimate_tokens(&last_response.content) + estimated_prompt_tokens;
+
         if config.renders_markdown {
             let parsed_content = markdown::parse(&last_response.content);
             #[cfg(debug_assertions)]
@@ -299,13 +300,25 @@ async fn stream_model_result(
                     last_response.content, parsed_content
                 );
             }
-            bot.edit_message_text(chat_id.to_owned(), editing_msg.id, parsed_content.content)
+            if let Err(first_trial_err) = bot
+                .edit_message_text(chat_id.to_owned(), editing_msg.id, parsed_content.content)
                 .entities(parsed_content.entities)
-                .await?;
-        } else {
-            bot.edit_message_text(chat_id.to_owned(), editing_msg.id, &last_response.content)
-                .await?;
+                .await
+            {
+                // TODO: test if the error is related to Markdown before
+                // fallback to raw contents.
+                error!(
+                    "failed to send message (will fallback to raw contents): {}",
+                    first_trial_err
+                );
+            } else {
+                return Ok(last_response);
+            }
         }
+
+        bot.edit_message_text(chat_id.to_owned(), editing_msg.id, &last_response.content)
+            .await?;
+
         return Ok(last_response);
     }
 

--- a/src/modules/chat/mod.rs
+++ b/src/modules/chat/mod.rs
@@ -290,11 +290,15 @@ async fn stream_model_result(
         // in stream mode. Therefore we need to estimate it locally.
         last_response.token_usage =
             openai_client::estimate_tokens(&last_response.content) + estimated_prompt_tokens;
-        let parsed_content = markdown::parse(&last_response.content);
-        println!("{:#?}", &parsed_content);
-        bot.edit_message_text(chat_id.to_owned(), editing_msg.id, parsed_content.content)
-            .entities(parsed_content.entities)
-            .await?;
+        if config.renders_markdown {
+            let parsed_content = markdown::parse(&last_response.content);
+            bot.edit_message_text(chat_id.to_owned(), editing_msg.id, parsed_content.content)
+                .entities(parsed_content.entities)
+                .await?;
+        } else {
+            bot.edit_message_text(chat_id.to_owned(), editing_msg.id, &last_response.content)
+                .await?;
+        }
         return Ok(last_response);
     }
 

--- a/src/modules/chat/mod.rs
+++ b/src/modules/chat/mod.rs
@@ -292,6 +292,13 @@ async fn stream_model_result(
             openai_client::estimate_tokens(&last_response.content) + estimated_prompt_tokens;
         if config.renders_markdown {
             let parsed_content = markdown::parse(&last_response.content);
+            #[cfg(debug_assertions)]
+            {
+                debug!(
+                    "rendered Markdown contents: {}\ninto: {:#?}",
+                    last_response.content, parsed_content
+                );
+            }
             bot.edit_message_text(chat_id.to_owned(), editing_msg.id, parsed_content.content)
                 .entities(parsed_content.entities)
                 .await?;

--- a/src/modules/chat/mod.rs
+++ b/src/modules/chat/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 mod braille;
+mod markdown;
 mod openai_client;
 mod session;
 mod session_mgr;
@@ -289,7 +290,10 @@ async fn stream_model_result(
         // in stream mode. Therefore we need to estimate it locally.
         last_response.token_usage =
             openai_client::estimate_tokens(&last_response.content) + estimated_prompt_tokens;
-        bot.edit_message_text(chat_id.to_owned(), editing_msg.id, &last_response.content)
+        let parsed_content = markdown::parse(&last_response.content);
+        println!("{:#?}", &parsed_content);
+        bot.edit_message_text(chat_id.to_owned(), editing_msg.id, parsed_content.content)
+            .entities(parsed_content.entities)
             .await?;
         return Ok(last_response);
     }

--- a/src/modules/chat/session.rs
+++ b/src/modules/chat/session.rs
@@ -1,13 +1,64 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
 use async_openai::types::{ChatCompletionRequestMessage as Message, Role};
 
 use crate::config::SharedConfig;
 
+#[derive(Debug, Clone)]
+pub struct HistoryMessage {
+    pub id: i64,
+    pub message: Message,
+}
+
+#[derive(Debug, Default)]
+struct HistoryMessagePool {
+    current_id: i64,
+    messages: HashMap<i64, HistoryMessage>,
+    deque: VecDeque<i64>,
+}
+
+impl HistoryMessagePool {
+    fn prepare_message(&mut self, message: Message) -> HistoryMessage {
+        let (id, _) = self.current_id.overflowing_add(1);
+        self.current_id = id;
+
+        HistoryMessage { id, message }
+    }
+
+    fn push_message(&mut self, message: HistoryMessage) {
+        let id = message.id;
+        self.messages.insert(id, message);
+        self.deque.push_back(id);
+    }
+
+    fn pop_message(&mut self) {
+        if let Some(evicted_id) = self.deque.pop_front() {
+            self.messages.remove(&evicted_id);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.deque.clear();
+        self.messages.clear();
+    }
+
+    fn len(&self) -> usize {
+        self.deque.len()
+    }
+
+    fn get_message(&self, id: &i64) -> Option<&HistoryMessage> {
+        self.messages.get(id)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &HistoryMessage> + '_ {
+        self.deque.iter().filter_map(|id| self.messages.get(id))
+    }
+}
+
 #[derive(Debug)]
 pub struct Session {
     system_message: Option<Message>,
-    messages: VecDeque<Message>,
+    history_messages: HistoryMessagePool,
     pending_message: Option<Message>,
     config: SharedConfig,
 }
@@ -16,7 +67,7 @@ impl Session {
     pub fn new(config: SharedConfig) -> Self {
         Self {
             system_message: None,
-            messages: VecDeque::with_capacity(6),
+            history_messages: Default::default(),
             pending_message: None,
             config,
         }
@@ -24,26 +75,36 @@ impl Session {
 
     pub fn reset(&mut self) {
         self.system_message = None;
-        self.messages.clear();
+        self.history_messages.clear();
         self.pending_message = None;
     }
 
-    pub fn add_message(&mut self, msg: Message) {
-        if matches!(msg.role, Role::System) {
+    pub fn prepare_history_message(&mut self, message: Message) -> HistoryMessage {
+        self.history_messages.prepare_message(message)
+    }
+
+    pub fn add_history_message(&mut self, message: HistoryMessage) {
+        if matches!(message.message.role, Role::System) {
             // Replace the previous system message, we only support
             // one system message at the same time.
-            self.system_message = Some(msg);
+            self.system_message = Some(message.message);
             return;
         }
 
-        if self.messages.len() >= (self.config.conversation_limit as usize) {
-            self.messages.pop_front();
+        if self.history_messages.len() >= (self.config.conversation_limit as usize) {
+            self.history_messages.pop_message();
         }
-        self.messages.push_back(msg);
+        self.history_messages.push_message(message);
+    }
+
+    pub fn get_history_message(&self, id: i64) -> Option<Message> {
+        self.history_messages
+            .get_message(&id)
+            .map(|m| m.message.clone())
     }
 
     pub fn get_history_messages(&self) -> Vec<Message> {
-        let msg_iter = self.messages.iter().cloned();
+        let msg_iter = self.history_messages.iter().map(|m| m.message.clone());
         if let Some(sys_msg) = &self.system_message {
             let prepend = [sys_msg.to_owned()];
             prepend.into_iter().chain(msg_iter).collect()

--- a/src/modules/chat/session_mgr.rs
+++ b/src/modules/chat/session_mgr.rs
@@ -31,10 +31,6 @@ impl SessionManager {
         self.with_mut_session(key, |session| session.reset());
     }
 
-    pub fn add_message_to_session(&self, key: String, msg: Message) {
-        self.with_mut_session(key, |session| session.add_message(msg));
-    }
-
     pub fn get_history_messages(&self, key: &str) -> Vec<Message> {
         self.with_mut_inner(|inner| {
             inner
@@ -53,15 +49,7 @@ impl SessionManager {
         self.with_mut_session(key, |session| session.swap_pending_message(msg))
     }
 
-    fn with_mut_inner<F, R>(&self, f: F) -> R
-    where
-        F: FnOnce(&mut SessionManagerInner) -> R,
-    {
-        let mut inner_mut = self.inner.lock().unwrap();
-        f(&mut inner_mut)
-    }
-
-    fn with_mut_session<F, R>(&self, key: String, f: F) -> R
+    pub fn with_mut_session<F, R>(&self, key: String, f: F) -> R
     where
         F: FnOnce(&mut Session) -> R,
     {
@@ -72,6 +60,14 @@ impl SessionManager {
                 .or_insert(Session::new(inner.config.clone()));
             f(session_mut)
         })
+    }
+
+    fn with_mut_inner<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut SessionManagerInner) -> R,
+    {
+        let mut inner_mut = self.inner.lock().unwrap();
+        f(&mut inner_mut)
     }
 }
 


### PR DESCRIPTION
This PR adds Markdown supports that renders contents returned from OpenAI server into Telegram's rich text format. Rather than directly rendering the Markdown contents to HTML, we parse them with a pull-mode parser and generate the message entities provided by Telegram. This approach ensures maximum compatibility with Telegram.

**Note:**
The feature is disabled by default, users may manually enable it in the configuration.