### PR TITLE
[EPIC] Dispatcher refactor

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,10 @@
 //! [`run`] function to start the bot server.
 
 use anyhow::Error;
-use teloxide::{prelude::*, types::MenuButton};
+use teloxide::{
+    prelude::*,
+    types::{BotCommand, MenuButton},
+};
 
 use crate::{
     config::{Config, SharedConfig},
@@ -18,7 +21,14 @@ use crate::{
 
 async fn update_menu(bot: Bot, module_mgr: &mut ModuleManager) -> HandlerResult {
     let mut commands = vec![];
-    module_mgr.with_all_modules(|m| commands.extend(m.commands().into_iter()));
+    module_mgr.with_all_modules(|m| {
+        commands.extend(
+            m.commands()
+                .into_iter()
+                .filter(|command| !command.is_hidden)
+                .map(|command| BotCommand::new(command.command, command.description)),
+        )
+    });
     Ok(bot.set_my_commands(commands).await.and(Ok(()))?)
 }
 

--- a/src/module_mgr.rs
+++ b/src/module_mgr.rs
@@ -4,17 +4,41 @@ use std::future::Future;
 
 use anyhow::Error;
 use teloxide::prelude::*;
-use teloxide::types::BotCommand;
 
 use crate::types::TeloxideHandler;
+
+pub struct Command {
+    pub command: String,
+    pub description: String,
+    pub handler: TeloxideHandler,
+    pub is_hidden: bool,
+}
+
+impl Command {
+    pub fn new(command: &str, description: &str, handler: TeloxideHandler) -> Self {
+        Self {
+            command: command.to_owned(),
+            description: description.to_owned(),
+            handler,
+            is_hidden: false,
+        }
+    }
+
+    pub fn hidden(mut self) -> Self {
+        self.is_hidden = true;
+        self
+    }
+}
 
 #[async_trait]
 pub trait Module {
     async fn register_dependency(&mut self, dep_map: &mut DependencyMap) -> Result<(), Error>;
 
-    fn handler_chain(&self) -> TeloxideHandler;
+    fn filter_handler(&self) -> TeloxideHandler {
+        dptree::entry()
+    }
 
-    fn commands(&self) -> Vec<BotCommand> {
+    fn commands(&self) -> Vec<Command> {
         vec![]
     }
 }

--- a/src/modules/admin/mod.rs
+++ b/src/modules/admin/mod.rs
@@ -5,15 +5,14 @@ use std::sync::Arc;
 use anyhow::Error;
 use teloxide::dptree::di::DependencySupplier;
 use teloxide::prelude::*;
-use teloxide::types::BotCommand;
 
 use crate::{
     config::SharedConfig,
     database::DatabaseManager,
-    module_mgr::Module,
+    module_mgr::{Command, Module},
     modules::prefs::PreferencesManager,
-    types::{HandlerResult, TeloxideHandler},
-    utils::dptree_ext::{command_filter, CommandArgs},
+    types::HandlerResult,
+    utils::dptree_ext::CommandArgs,
 };
 pub(crate) use member_mgr::MemberManager;
 
@@ -189,17 +188,12 @@ impl Module for Admin {
         Ok(())
     }
 
-    fn handler_chain(&self) -> TeloxideHandler {
-        dptree::entry().branch(
-            Update::filter_message()
-                .branch(dptree::filter_map(command_filter("set_public")).endpoint(set_public))
-                .branch(dptree::filter_map(command_filter("add_member")).endpoint(add_member))
-                .branch(dptree::filter_map(command_filter("del_member")).endpoint(delete_member)),
-        )
-    }
-
-    fn commands(&self) -> Vec<BotCommand> {
+    fn commands(&self) -> Vec<Command> {
         // Don't reveal admin commands to other users.
-        vec![]
+        vec![
+            Command::new("set_public", "", dptree::endpoint(set_public)).hidden(),
+            Command::new("add_member", "", dptree::endpoint(add_member)).hidden(),
+            Command::new("del_member", "", dptree::endpoint(delete_member)).hidden(),
+        ]
     }
 }

--- a/src/modules/config.rs
+++ b/src/modules/config.rs
@@ -1,8 +1,7 @@
 use anyhow::Error;
-use teloxide::dispatching::DpHandlerDescription;
 use teloxide::prelude::*;
 
-use crate::{config::SharedConfig, module_mgr::Module, types::HandlerResult};
+use crate::{config::SharedConfig, module_mgr::Module};
 
 pub(crate) struct Config {
     config: Option<SharedConfig>,
@@ -21,11 +20,5 @@ impl Module for Config {
     async fn register_dependency(&mut self, dep_map: &mut DependencyMap) -> Result<(), Error> {
         dep_map.insert(self.config.take().unwrap());
         Ok(())
-    }
-
-    fn handler_chain(
-        &self,
-    ) -> Handler<'static, DependencyMap, HandlerResult, DpHandlerDescription> {
-        dptree::entry()
     }
 }

--- a/src/modules/prefs/mod.rs
+++ b/src/modules/prefs/mod.rs
@@ -2,9 +2,8 @@ mod prefs_mgr;
 
 use anyhow::Error;
 use teloxide::prelude::*;
-use teloxide::types::BotCommand;
 
-use crate::{database::DatabaseManager, module_mgr::Module, types::TeloxideHandler};
+use crate::{database::DatabaseManager, module_mgr::Module};
 pub(crate) use prefs_mgr::PreferencesManager;
 
 pub(crate) struct Prefs {
@@ -23,13 +22,5 @@ impl Module for Prefs {
         let prefs_mgr = PreferencesManager::with_db_manager(self.db_mgr.clone()).await?;
         dep_map.insert(prefs_mgr);
         Ok(())
-    }
-
-    fn handler_chain(&self) -> TeloxideHandler {
-        dptree::entry()
-    }
-
-    fn commands(&self) -> Vec<BotCommand> {
-        vec![]
     }
 }

--- a/src/modules/stats/mod.rs
+++ b/src/modules/stats/mod.rs
@@ -3,12 +3,12 @@ mod stats_mgr;
 use std::fmt::Write;
 
 use anyhow::Error;
-use teloxide::dispatching::DpHandlerDescription;
 use teloxide::prelude::*;
-use teloxide::types::BotCommand;
 
 use crate::{
-    database::DatabaseManager, module_mgr::Module, types::HandlerResult, utils::dptree_ext,
+    database::DatabaseManager,
+    module_mgr::{Command, Module},
+    types::HandlerResult,
 };
 pub(crate) use stats_mgr::StatsManager;
 
@@ -49,20 +49,11 @@ impl Module for Stats {
         Ok(())
     }
 
-    fn handler_chain(
-        &self,
-    ) -> Handler<'static, DependencyMap, HandlerResult, DpHandlerDescription> {
-        dptree::entry().branch(
-            Update::filter_message()
-                .filter_map(dptree_ext::command_filter("stats"))
-                .endpoint(handle_show_stats),
-        )
-    }
-
-    fn commands(&self) -> Vec<BotCommand> {
-        vec![BotCommand::new(
+    fn commands(&self) -> Vec<Command> {
+        vec![Command::new(
             "stats",
             "Show the token usage and other stats",
+            dptree::endpoint(handle_show_stats),
         )]
     }
 }

--- a/src/utils/dptree_ext.rs
+++ b/src/utils/dptree_ext.rs
@@ -52,10 +52,10 @@ fn extract_command_args<'i>(input: &'i str, cmd: &str, username: &str) -> Option
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CommandArgs(pub String);
 
-pub fn command_filter(cmd: &'static str) -> impl Fn(Message, Me) -> Option<CommandArgs> {
+pub fn command_filter(cmd: String) -> impl Fn(Message, Me) -> Option<CommandArgs> {
     move |msg: Message, me: Me| {
         let text = msg.text()?;
-        extract_command_args(text, cmd, me.username()).map(|a| CommandArgs(a.to_owned()))
+        extract_command_args(text, &cmd, me.username()).map(|a| CommandArgs(a.to_owned()))
     }
 }
 


### PR DESCRIPTION
A problem raised when we are working on Dall-E feature: We need the bot to enter a dialogue mode where the bot ask questions, and users can reply back to continue the painting. The current dispatcher will literally not support this operation, because the handlers are performed one-by-one in registration order. Registering `DallE` module earlier than `Chat` module seems to solve our problem, but that would just be a workaround.

The common usage of the bot is chatting, it's the default mode. However, sometimes, some other modules may want to respond to a message with higher priority temporarily. This is where `Conversation` comes in. It's similar to `Dialogue` in teloxide, but instead of single-typed state, we support multiple-typed state, and each type of state can provide different handlers. Back to the problem we issued before. When user want to use Dall-E, it can type let's say `/paint`, then the bot will enter a Dall-E painting conversation. User can answer the questions asked by bot in the conversation without being intercepted by `Chat` module. This is implemented by a handler ahead of regular module handlers.

As we are doing the refactor, we also refined how commands are handled. In the current implementation, command providing and handling are separated, which is not that scalable and maintainable. In the next version, it will also be unified.

Here is a overview of how updates are processed in the new dispatching pipeline:

```
[Updates] --> (Preflight Filter) --> (Conversation Handler)
                                 |-> (Command Handler)
                                 |-> (Module Filter Handler)
                                 |-> (Default Handler)

Legend: [Input]
        (Handler)
```